### PR TITLE
Kafka MultiDC sinink

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/multidc/sink/KafkaMultiDCSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/multidc/sink/KafkaMultiDCSink.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.kafka.multidc.sink;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.log4j.Logger;
+import org.wso2.extension.siddhi.io.kafka.sink.KafkaSink;
+import org.wso2.siddhi.annotation.Example;
+import org.wso2.siddhi.annotation.Extension;
+import org.wso2.siddhi.annotation.Parameter;
+import org.wso2.siddhi.annotation.util.DataType;
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.ConnectionUnavailableException;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.core.util.transport.DynamicOptions;
+import org.wso2.siddhi.core.util.transport.OptionHolder;
+import org.wso2.siddhi.query.api.definition.StreamDefinition;
+import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * This class implements a Kafka sink to publish Siddhi events to multiple kafka clusters. This sink is useful in
+ * multi data center deployments where we have two identical setups replicated in two physical locations
+ */
+@Extension(
+        name = "kafkaMultiDC",
+        namespace = "sink",
+        description = "The Kafka Sink publishes records to a topic with the default a partition only for a Kafka " +
+                "cluster which are in format such as `text`, `XML` and `JSON`.\n"
+                + "The Kafka Sink will create the default partition for a given topic, if the topic is not already "
+                + "been created in the Kafka cluster. The publishing topic and partition can be a dynamic value taken"
+                + " from the Siddhi event",
+        parameters = {
+                @Parameter(name = "bootstrap.servers",
+                        description = "This should contain the kafka server list which the kafka sink should be "
+                                + "publishing to. This should be given in comma separated values. There should be " +
+                                "at least two in this list."
+                                + "eg: 'localhost:9092,localhost:9093' ",
+                        type = {DataType.STRING}),
+                @Parameter(name = "topic",
+                        description = "The topic which the sink should publish to. Only one topic should be "
+                                + "given",
+                        type = {DataType.STRING}),
+                @Parameter(name = "sequence.id",
+                        description = "Unique identifier to identify the messages published by this sink. Using this " +
+                                "id receivers can identify the sink which produced the message",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = "null"),
+                @Parameter(name = "key",
+                        description = "The key will contain the values which is used to maintain ordering in a "
+                                + "kafka partition.",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = "null"),
+                @Parameter(name = "partition.no",
+                        description = "The partition number for the given topic. Only one partition id can be "
+                                + "defined. If this is not defined, the sink will be publishing to the topic's "
+                                + "default partition number 0.",
+                        type = {DataType.INT},
+                        optional = true,
+                        defaultValue = "0"),
+                @Parameter(name = "optional.configuration",
+                        description = "This may contain all the other possible configurations which the consumer "
+                                + "should be created with."
+                                + "eg: producer.type:async,batch.size:200",
+                        optional = true,
+                        type = {DataType.STRING},
+                        defaultValue = "null")
+        },
+        examples = {
+                @Example(
+                        description = "The following query will publish to  default (0th) "
+                                + "partition of the brokers in two data centers ",
+                        syntax = "@App:name('TestExecutionPlan') \n" +
+                                "define stream FooStream (symbol string, price float, volume long); \n" +
+                                "@info(name = 'query1') \n" +
+                                "@sink("
+                                + "type='kafkaMultiDC', "
+                                + "topic='myTopic', "
+                                + "partition='0',"
+                                + "bootstrap.servers='host1:9092, host2:9092', "
+                                + "@map(type='xml'))" +
+                                "Define stream BarStream (symbol string, price float, volume long);\n" +
+                                "from FooStream select symbol, price, volume insert into BarStream;\n")}
+)
+// TODO : improve the prameter list to contain partition.no
+public class KafkaMultiDCSink extends KafkaSink {
+    List<Producer<String, String>> producers = new ArrayList<>();
+    private String topic;
+    private Integer partitionNo;
+    private static final Logger LOG = Logger.getLogger(KafkaMultiDCSink.class);
+
+    @Override
+    protected void init(StreamDefinition outputStreamDefinition, OptionHolder optionHolder,
+                       ConfigReader sinkConfigReader, SiddhiAppContext siddhiAppContext) {
+        super.init(outputStreamDefinition, optionHolder, sinkConfigReader, siddhiAppContext);
+        topic = optionHolder.validateAndGetStaticValue(KAFKA_PUBLISH_TOPIC);
+        partitionNo = Integer.parseInt(optionHolder.validateAndGetStaticValue(KAFKA_PARTITION_NO, "0"));
+        if (bootstrapServers.split(",").length != 2) {
+            throw new SiddhiAppValidationException("There should be two servers listed in 'bootstrap.servers' " +
+                    "configuration");
+        }
+    }
+
+    @Override
+    public String[] getSupportedDynamicOptions() {
+        return new String[]{KAFKA_MESSAGE_KEY};
+    }
+
+    @Override
+    public void connect() throws ConnectionUnavailableException {
+        Properties props = new Properties();
+        props.put("acks", "all");
+        props.put("retries", 0);
+        props.put("batch.size", 16384);
+        props.put("linger.ms", 1);
+        props.put("buffer.memory", 33554432);
+        props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+        readOptionalConfigs(props, optionalConfigs);
+
+        String[] bootstrapServersList = bootstrapServers.split(",");
+        for (int index = 0; index < bootstrapServersList.length; index++) {
+            String server = bootstrapServersList[index].trim();
+            props.put("bootstrap.servers", server);
+            Producer<String, String> producer = new KafkaProducer<>(props);
+            producers.add(producer);
+            LOG.info("Kafka producer created for Kafka cluster :" + server);
+        }
+    }
+
+
+    @Override
+    public void publish(Object payload, DynamicOptions transportOptions) throws ConnectionUnavailableException {
+        String key = keyOption.getValue(transportOptions);
+
+        StringBuilder strPayload = new StringBuilder();
+        strPayload.append(sequenceId).append(SEQ_NO_HEADER_FIELD_SEPERATOR).append(lastSentSequenceNo)
+                .append(SEQ_NO_HEADER_DELIMITER)
+                .append(payload.toString());
+        lastSentSequenceNo.incrementAndGet();
+
+        for (Producer producer : producers) {
+            try {
+                producer.send(new ProducerRecord<>(topic, partitionNo, key, strPayload.toString()));
+            } catch (Exception e) {
+                LOG.error(String.format("Failed to publish the message to [topic] %s. Error: %s. Sequence Number " +
+                        ": %d", topic, e.getMessage(), lastSentSequenceNo.get() - 1), e);
+            }
+        }
+    }
+
+    @Override
+    public void disconnect() {
+        for (Producer producer : producers) {
+            producer.flush();
+            producer.close();
+        }
+        producers.clear();
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/multidc/source/KafkaMultiDCSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/multidc/source/KafkaMultiDCSource.java
@@ -1,0 +1,7 @@
+package org.wso2.extension.siddhi.io.kafka.multidc.source;
+
+/**
+ * Created by sajith on 9/19/17.
+ */
+public class KafkaMultiDCSource {
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/sink/KafkaSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/sink/KafkaSink.java
@@ -38,7 +38,6 @@ import org.wso2.siddhi.query.api.definition.StreamDefinition;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -122,29 +121,28 @@ import java.util.concurrent.atomic.AtomicInteger;
 )
 public class KafkaSink extends Sink {
 
-    private ScheduledExecutorService executorService;
     private Producer<String, String>  producer;
-    private Option topicOption = null;
-    private String bootstrapServers;
-    private String optionalConfigs;
-    private Option partitionOption;
-    private Boolean isSequenced = false;
-    private AtomicInteger lastSentSequenceNo = new AtomicInteger(0);
-    private String sequenceId = null;
+    protected Option topicOption = null;
+    protected String bootstrapServers;
+    protected String optionalConfigs;
+    protected Option partitionOption;
+    protected Boolean isSequenced = false;
+    protected AtomicInteger lastSentSequenceNo = new AtomicInteger(0);
+    protected String sequenceId = null;
 
     public static final String LAST_SENT_SEQ_NO_PERSIST_KEY = "lastSentSequenceNo";
     public static final String SEQ_NO_HEADER_DELIMITER = "~";
     public static final String SEQ_NO_HEADER_FIELD_SEPERATOR = ":";
-    private Option keyOption;
+    protected Option keyOption;
 
-    private static final String KAFKA_PUBLISH_TOPIC = "topic";
-    private static final String KAFKA_BROKER_LIST = "bootstrap.servers";
-    private static final String KAFKA_MESSAGE_KEY = "key";
-    private static final String KAFKA_OPTIONAL_CONFIGURATION_PROPERTIES = "optional.configuration";
-    private static final String HEADER_SEPARATOR = ",";
-    private static final String ENTRY_SEPARATOR = ":";
-    private static final String KAFKA_PARTITION_NO = "partition.no";
-    private static final String SEQ_ID = "sequence.id";
+    protected static final String KAFKA_PUBLISH_TOPIC = "topic";
+    protected static final String KAFKA_BROKER_LIST = "bootstrap.servers";
+    protected static final String KAFKA_MESSAGE_KEY = "key";
+    protected static final String KAFKA_OPTIONAL_CONFIGURATION_PROPERTIES = "optional.configuration";
+    protected static final String HEADER_SEPARATOR = ",";
+    protected static final String ENTRY_SEPARATOR = ":";
+    protected static final String KAFKA_PARTITION_NO = "partition.no";
+    protected static final String SEQ_ID = "sequence.id";
 
     private static final Logger LOG = Logger.getLogger(KafkaSink.class);
 
@@ -157,7 +155,6 @@ public class KafkaSink extends Sink {
         partitionOption = optionHolder.getOrCreateOption(KAFKA_PARTITION_NO, null);
         sequenceId = optionHolder.validateAndGetStaticValue(SEQ_ID, null);
         isSequenced = (sequenceId == null) ? false : true;
-        executorService = siddhiAppContext.getScheduledExecutorService();
         keyOption = optionHolder.getOrCreateOption(KAFKA_MESSAGE_KEY, null);
     }
 
@@ -173,19 +170,8 @@ public class KafkaSink extends Sink {
         props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
         props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
 
-        if (optionalConfigs != null && optionalConfigs.isEmpty()) {
-            String[] optionalProperties = optionalConfigs.split(HEADER_SEPARATOR);
-            if (optionalProperties.length > 0) {
-                for (String header : optionalProperties) {
-                    try {
-                        String[] configPropertyWithValue = header.split(ENTRY_SEPARATOR, 2);
-                        props.put(configPropertyWithValue[0], configPropertyWithValue[1]);
-                    } catch (Exception e) {
-                        LOG.warn("Optional property '" + header + "' is not defined in the correct format.", e);
-                    }
-                }
-            }
-        }
+        readOptionalConfigs(props, optionalConfigs);
+
         producer = new KafkaProducer<>(props);
         LOG.info("Kafka producer created.");
     }
@@ -259,6 +245,22 @@ public class KafkaSink extends Sink {
             Object sequenceNumber = state.get(LAST_SENT_SEQ_NO_PERSIST_KEY);
             if (sequenceNumber != null) {
                 lastSentSequenceNo.set((Integer) sequenceNumber);
+            }
+        }
+    }
+
+    public static void readOptionalConfigs(Properties props, String optionalConfigs) {
+        if (optionalConfigs != null && !optionalConfigs.isEmpty()) {
+            String[] optionalProperties = optionalConfigs.split(HEADER_SEPARATOR);
+            if (optionalProperties.length > 0) {
+                for (String header : optionalProperties) {
+                    try {
+                        String[] configPropertyWithValue = header.split(ENTRY_SEPARATOR, 2);
+                        props.put(configPropertyWithValue[0], configPropertyWithValue[1]);
+                    } catch (Exception e) {
+                        LOG.warn("Optional property '" + header + "' is not defined in the correct format.", e);
+                    }
+                }
             }
         }
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/KafkaConsumerThread.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/KafkaConsumerThread.java
@@ -176,7 +176,7 @@ public class KafkaConsumerThread implements Runnable {
                                     String eventBody = event.substring(headerStartingIndex + 1);
                                     sourceEventListener.onEvent(eventBody, new String[0]);
                                     if (LOG.isDebugEnabled()) {
-                                    LOG.debug("Last Received SeqNo Updated to:" + seqNo + " for " +
+                                        LOG.debug("Last Received SeqNo Updated to:" + seqNo + " for " +
                                             "SeqKey:[" + sequenceKey.toString() + "] in Kafka consumer thread:"
                                             + consumerThreadId);
                                     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/KafkaSource.java
@@ -204,7 +204,7 @@ public class KafkaSource extends Source {
     public void disconnect() {
         if (consumerKafkaGroup != null) {
             consumerKafkaGroup.shutdown();
-            LOG.debug("Kafka Adapter disconnected for topic/s" +
+            LOG.info("Kafka Adapter disconnected for topic/s" +
                               optionHolder.validateAndGetStaticValue(ADAPTOR_SUBSCRIBER_TOPIC));
         }
     }
@@ -218,10 +218,8 @@ public class KafkaSource extends Source {
     public void pause() {
         if (consumerKafkaGroup != null) {
             consumerKafkaGroup.pause();
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Kafka Adapter paused for topic/s" + optionHolder.validateAndGetStaticValue
+                LOG.info("Kafka Adapter paused for topic/s" + optionHolder.validateAndGetStaticValue
                         (ADAPTOR_SUBSCRIBER_TOPIC));
-            }
         }
     }
 

--- a/component/src/test/java/org/wso2/extension/siddhi/io/kafka/SequencedMessagingTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/kafka/SequencedMessagingTestCase.java
@@ -307,7 +307,7 @@ public class SequencedMessagingTestCase {
 
         dataReceiveApp.addCallback("BarStream1", new StreamCallback() {
             @Override
-            public void receive(Event[] events) {
+            public synchronized void receive(Event[] events) {
                 count += events.length;
             }
         });
@@ -351,6 +351,7 @@ public class SequencedMessagingTestCase {
         while (!eventSender.isDone()) {
             Thread.sleep(100);
         }
+        Thread.sleep(5000);
 
         // Shutting down the external relay app to mimic a node failure and starting it again like a restart so that
         // after the restart it will replay the last published 5 messages as it's not being persisted.
@@ -423,7 +424,7 @@ public class SequencedMessagingTestCase {
 
         dataReceiveApp.addCallback("BarStream1", new StreamCallback() {
             @Override
-            public void receive(Event[] events) {
+            public synchronized void receive(Event[] events) {
                 count += events.length;
             }
         });
@@ -540,7 +541,7 @@ public class SequencedMessagingTestCase {
 
         dataReceiveApp.addCallback("BarStream1", new StreamCallback() {
             @Override
-            public void receive(Event[] events) {
+            public synchronized void receive(Event[] events) {
                 count += events.length;
             }
         });

--- a/component/src/test/java/org/wso2/extension/siddhi/io/kafka/SequencedMessagingTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/kafka/SequencedMessagingTestCase.java
@@ -108,7 +108,7 @@ public class SequencedMessagingTestCase {
 
         dataReceiveApp.addCallback("BarStream1", new StreamCallback() {
             @Override
-            public void receive(Event[] events) {
+            public synchronized void receive(Event[] events) {
                 count += events.length;
             }
         });
@@ -140,13 +140,8 @@ public class SequencedMessagingTestCase {
         LOG.info("Finished persisting the state of external event relay siddhi app");
 
         // Send more events after persisting the state
-        eventSender = executorService.submit(new Runnable() {
-            @Override
-            public void run() {
-                KafkaTestUtil.kafkaPublisher(
-                        new String[]{"ExternalTopic-1"}, 1, 5, 100, false, null, true);
-            }
-        });
+        eventSender = executorService.submit((Runnable) () -> KafkaTestUtil.kafkaPublisher(
+                new String[]{"ExternalTopic-1"}, 1, 5, 100, false, null, true));
         while (!eventSender.isDone()) {
             Thread.sleep(100);
         }
@@ -206,7 +201,7 @@ public class SequencedMessagingTestCase {
 
         dataReceiveApp.addCallback("BarStream1", new StreamCallback() {
             @Override
-            public void receive(Event[] events) {
+            public synchronized void receive(Event[] events) {
                 count += events.length;
             }
         });
@@ -646,7 +641,7 @@ public class SequencedMessagingTestCase {
 
         dataReceiveApp.addCallback("BarStream1", new StreamCallback() {
             @Override
-            public void receive(Event[] events) {
+            public synchronized void receive(Event[] events) {
                 count += events.length;
             }
         });

--- a/component/src/test/java/org/wso2/extension/siddhi/io/kafka/multidc/KafkaMultiDCSinkTestCases.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/kafka/multidc/KafkaMultiDCSinkTestCases.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.io.kafka.multidc;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.extension.siddhi.io.kafka.KafkaTestUtil;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.stream.output.StreamCallback;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class KafkaMultiDCSinkTestCases {
+    static final Logger LOG = Logger.getLogger(KafkaMultiDCSinkTestCases.class);
+    private static ExecutorService executorService;
+    private volatile int count;
+    private volatile boolean eventArrived;
+    private volatile List<String> receivedEventNameList;
+    private volatile List<Long> receivedValueList;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        try {
+            executorService = Executors.newFixedThreadPool(5);
+            KafkaTestUtil.cleanLogDir();
+            KafkaTestUtil.setupKafkaBroker();
+            Thread.sleep(1000);
+            KafkaTestUtil.cleanLogDir2();
+            KafkaTestUtil.setupKafkaBroker2();
+            Thread.sleep(1000);
+        } catch (Exception e) {
+            throw new RemoteException("Exception caught when starting server", e);
+        }
+    }
+
+    @AfterClass
+    public static void stopKafkaBroker() throws InterruptedException {
+        KafkaTestUtil.stopKafkaBroker();
+        Thread.sleep(1000);
+        KafkaTestUtil.stopKafkaBroker2();
+    }
+
+    @BeforeMethod
+    public void reset() {
+        count = 0;
+        eventArrived = false;
+    }
+
+    @Test
+    public void testMultiDCSinkWithBothBrokersRunning() throws InterruptedException {
+        LOG.info("Creating test for publishing events for static topic without a partition");
+        String topics[] = new String[]{"myTopic"};
+        KafkaTestUtil.createTopic(topics, 1);
+        KafkaTestUtil.createTopic(KafkaTestUtil.ZK_SERVER2_CON_STRING, topics, 1);
+        Thread.sleep(4000);
+        receivedEventNameList = new ArrayList<>(3);
+        receivedValueList = new ArrayList<>(3);
+
+        SiddhiManager sourceOneSiddhiManager = new SiddhiManager();
+        SiddhiAppRuntime sourceOneApp = sourceOneSiddhiManager.createSiddhiAppRuntime(
+                "@App:name('SourceOneSiddhiApp') " +
+                        "define stream BarStream2 (symbol string, price float, volume long); " +
+                        "@info(name = 'query1') " +
+                        "@source(type='kafka', topic.list='myTopic', group.id='single_topic_test'," +
+                        "partition.no.list='0', seq.enabled='true'," +
+                        "threading.option='single.thread', bootstrap.servers='localhost:9092'," +
+                        "@map(type='xml'))" +
+                        "Define stream FooStream2 (symbol string, price float, volume long);" +
+                        "from FooStream2 select symbol, price, volume insert into BarStream2;");
+
+        sourceOneApp.addCallback("BarStream2", new StreamCallback() {
+            @Override
+            public synchronized void receive(Event[] events) {
+                for (Event event : events) {
+                    LOG.info(event);
+                    eventArrived = true;
+                    count++;
+                    receivedEventNameList.add(event.getData(0).toString());
+                    receivedValueList.add((long) event.getData(2));
+                }
+            }
+        });
+        sourceOneApp.start();
+        Thread.sleep(4000);
+
+        SiddhiManager sourceTwoSiddhiManager = new SiddhiManager();
+        SiddhiAppRuntime sourceTwoApp = sourceTwoSiddhiManager.createSiddhiAppRuntime(
+                "@App:name('SourceTwoSiddhiApp') " +
+                        "define stream BarStream2 (symbol string, price float, volume long); " +
+                        "@info(name = 'query1') " +
+                        "@source(type='kafka', topic.list='myTopic', group.id='single_topic_test'," +
+                        "partition.no.list='0', seq.enabled='true'," +
+                        "threading.option='single.thread', bootstrap.servers='localhost:9093'," +
+                        "@map(type='xml'))" +
+                        "Define stream FooStream2 (symbol string, price float, volume long);" +
+                        "from FooStream2 select symbol, price, volume insert into BarStream2;");
+
+        sourceTwoApp.addCallback("BarStream2", new StreamCallback() {
+            @Override
+            public synchronized void receive(Event[] events) {
+                for (Event event : events) {
+                    LOG.info(event);
+                    eventArrived = true;
+                    count++;
+                }
+            }
+        });
+        sourceTwoApp.start();
+        Thread.sleep(4000);
+
+        String sinkApp = "@App:name('SinkSiddhiApp') \n"
+                    + "define stream FooStream (symbol string, price float, volume long); \n"
+                    + "@info(name = 'query1') \n"
+                    + "@sink("
+                    + "type='kafkaMultiDC', "
+                    + "topic='myTopic', "
+                    + "partition='0',"
+                    + "bootstrap.servers='localhost:9092,localhost:9093', "
+                    + "@map(type='xml'))" +
+                    "Define stream BarStream (symbol string, price float, volume long);\n" +
+                    "from FooStream select symbol, price, volume insert into BarStream;\n";
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntimeSink = siddhiManager.createSiddhiAppRuntime(sinkApp);
+        InputHandler fooStream = siddhiAppRuntimeSink.getInputHandler("BarStream");
+        siddhiAppRuntimeSink.start();
+        Thread.sleep(4000);
+        fooStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        fooStream.send(new Object[]{"WSO2", 75.6f, 102L});
+        fooStream.send(new Object[]{"WSO2", 57.6f, 103L});
+        Thread.sleep(4000);
+
+        Assert.assertTrue(count == 6);
+    }
+
+    /*
+    Even if one of the brokers are failing publishing should not be stopped for the other broker. Therefore, one
+    siddhi app must receive events.
+     */
+    @Test (dependsOnMethods = "testMultiDCSinkWithBothBrokersRunning")
+    public void testMultiDCSinkWithOneBrokersFailing() throws InterruptedException {
+        LOG.info("Creating test for publishing events for static topic without a partition");
+        String topics[] = new String[]{"myTopic"};
+        KafkaTestUtil.createTopic(topics, 1);
+
+        // Stopping 2nd Kafka broker to mimic a broker failure
+        KafkaTestUtil.stopKafkaBroker2();
+        Thread.sleep(4000);
+
+        SiddhiManager sourceOneSiddhiManager = new SiddhiManager();
+        SiddhiAppRuntime sourceOneApp = sourceOneSiddhiManager.createSiddhiAppRuntime(
+                "@App:name('SourceSiddhiApp') " +
+                        "define stream BarStream2 (symbol string, price float, volume long); " +
+                        "@info(name = 'query1') " +
+                        "@source(type='kafka', topic.list='myTopic', group.id='single_topic_test'," +
+                        "partition.no.list='0', seq.enabled='true'," +
+                        "threading.option='single.thread', bootstrap.servers='localhost:9092'," +
+                        "@map(type='xml'))" +
+                        "Define stream FooStream2 (symbol string, price float, volume long);" +
+                        "from FooStream2 select symbol, price, volume insert into BarStream2;");
+
+        sourceOneApp.addCallback("BarStream2", new StreamCallback() {
+            @Override
+            public synchronized void receive(Event[] events) {
+                for (Event event : events) {
+                    LOG.info(event);
+                    count++;
+                }
+            }
+        });
+        sourceOneApp.start();
+        Thread.sleep(4000);
+
+        String sinkApp = "@App:name('SinkSiddhiApp') \n"
+                + "define stream FooStream (symbol string, price float, volume long); \n"
+                + "@info(name = 'query1') \n"
+                + "@sink("
+                + "type='kafkaMultiDC', "
+                + "topic='myTopic', "
+                + "partition='0',"
+                + "bootstrap.servers='localhost:9092,localhost:9093', "
+                + "@map(type='xml'))" +
+                "Define stream BarStream (symbol string, price float, volume long);\n" +
+                "from FooStream select symbol, price, volume insert into BarStream;\n";
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntimeSink = siddhiManager.createSiddhiAppRuntime(sinkApp);
+        InputHandler fooStream = siddhiAppRuntimeSink.getInputHandler("BarStream");
+        siddhiAppRuntimeSink.start();
+        Thread.sleep(4000);
+        fooStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        fooStream.send(new Object[]{"WSO2", 75.6f, 102L});
+        fooStream.send(new Object[]{"WSO2", 57.6f, 103L});
+        Thread.sleep(4000);
+
+        Assert.assertTrue(count == 3);
+    }
+
+}

--- a/component/src/test/java/org/wso2/extension/siddhi/io/kafka/sink/KafkaSinkTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/kafka/sink/KafkaSinkTestCase.java
@@ -76,7 +76,7 @@ public class KafkaSinkTestCase {
         try {
             SiddhiManager siddhiManager = new SiddhiManager();
             SiddhiAppRuntime siddhiAppRuntimeSource = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan2') " +
+                    "@App:name('TestExecutionPlan1') " +
                             "define stream BarStream2 (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@source(type='kafka', topic.list='single_topic', group.id='single_topic_test', " +
@@ -169,7 +169,7 @@ public class KafkaSinkTestCase {
             siddhiAppRuntimeSource.start();
             Thread.sleep(4000);
             SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan3') " +
                             "define stream FooStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@sink(type='kafka', topic='topic_with_two_partitions_sub0', partition.no='0', "
@@ -214,7 +214,7 @@ public class KafkaSinkTestCase {
         try {
             SiddhiManager siddhiManager = new SiddhiManager();
             SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan4') " +
                             "define stream FooStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@sink(type='kafka', topic='invalid_topic_without_partition2', "
@@ -231,7 +231,7 @@ public class KafkaSinkTestCase {
             // will create the topic.
             Thread.sleep(2000);
             SiddhiAppRuntime siddhiAppRuntimeSource = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan2') " +
+                    "@App:name('TestExecutionPlan5') " +
                             "define stream BarStream2 (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@source(type='kafka', topic.list='invalid_topic_without_partition2', "
@@ -287,7 +287,7 @@ public class KafkaSinkTestCase {
         try {
             SiddhiManager siddhiManager = new SiddhiManager();
             SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan6') " +
                             "define stream FooStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@sink(type='kafka', topic='invalid_topic_with_partition', "
@@ -304,7 +304,7 @@ public class KafkaSinkTestCase {
             // will create the topic.
             Thread.sleep(2000);
             SiddhiAppRuntime siddhiAppRuntimeSource = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan2') " +
+                    "@App:name('TestExecutionPlan7') " +
                             "define stream BarStream2 (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@source(type='kafka', topic.list='invalid_topic_with_partition', "
@@ -363,7 +363,7 @@ public class KafkaSinkTestCase {
         try {
             SiddhiManager siddhiManager = new SiddhiManager();
             SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan8') " +
                             "define stream FooStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@sink(type='kafka', topic='invalid_topic_with_partition_3', "
@@ -380,7 +380,7 @@ public class KafkaSinkTestCase {
             // will create the topic.
             Thread.sleep(2000);
             SiddhiAppRuntime siddhiAppRuntimeSource = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan2') " +
+                    "@App:name('TestExecutionPlan9') " +
                             "define stream BarStream2 (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@source(type='kafka', topic.list='invalid_topic_with_partition_3', "
@@ -437,7 +437,7 @@ public class KafkaSinkTestCase {
         try {
             SiddhiManager siddhiManager = new SiddhiManager();
             SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan10') " +
                             "define stream FooStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@sink(type='kafka', topic='invalid_topic_with_partition_2', "
@@ -454,7 +454,7 @@ public class KafkaSinkTestCase {
             // will create the topic.
             Thread.sleep(2000);
             SiddhiAppRuntime siddhiAppRuntimeSource = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan2') " +
+                    "@App:name('TestExecutionPlan11') " +
                             "define stream BarStream2 (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@source(type='kafka', topic.list='invalid_topic_with_partition_2', "
@@ -501,7 +501,7 @@ public class KafkaSinkTestCase {
             Thread.sleep(4000);
             SiddhiManager siddhiManager = new SiddhiManager();
             SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan12') " +
                             "define stream FooStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@sink(type='kafka', topic='{{symbol}}', bootstrap.servers='localhost:9092', " +
@@ -513,7 +513,7 @@ public class KafkaSinkTestCase {
 
 
             SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan13') " +
                             "define stream BarStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@source(type='kafka', topic.list='multiple_topic1,multiple_topic2', "
@@ -571,7 +571,7 @@ public class KafkaSinkTestCase {
             Thread.sleep(10000);
             SiddhiManager siddhiManager = new SiddhiManager();
             SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan14') " +
                             "define stream FooStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@sink(type='kafka', topic='{{symbol}}', partition.no='{{volume}}', "
@@ -584,7 +584,7 @@ public class KafkaSinkTestCase {
 
 
             SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan') " +
+                    "@App:name('TestExecutionPlan15') " +
                             "define stream BarStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@source(type='kafka', "

--- a/component/src/test/java/org/wso2/extension/siddhi/io/kafka/source/KafkaSourceTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/kafka/source/KafkaSourceTestCase.java
@@ -1117,7 +1117,7 @@ public class KafkaSourceTestCase {
                             "Define stream FooStream (symbol string, price float, volume long);" +
                             "from FooStream select symbol, price, volume insert into BarStream;");
             SiddhiAppRuntime siddhiAppRuntime2 = siddhiManager.createSiddhiAppRuntime(
-                    "@App:name('TestExecutionPlan2') " +
+                    "@App:name('TestExecutionPlan21') " +
                             "define stream BarStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
                             "@source(type='kafka', "

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -22,10 +22,11 @@
 <suite name="Siddhi-Execution-Kafka_Test-Suite">
     <test name="siddhi-execution-kafka-unit-tests" preserve-order="true">
         <classes>
-            <class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceTestCase" />
+            <!--class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceTestCase" /-->
             <!-- TODO uncomment when the text mapper is released -->
-            <!--<class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceHATestCase" />-->
-            <class name="org.wso2.extension.siddhi.io.kafka.sink.KafkaSinkTestCase" />
+            <!--<class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceHATestCase" />
+            <class name="org.wso2.extension.siddhi.io.kafka.sink.KafkaSinkTestCase" />-->
+            <class name="org.wso2.extension.siddhi.io.kafka.SequencedMessagingTestCase" />
         </classes>
     </test>
 </suite>

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -22,11 +22,12 @@
 <suite name="Siddhi-Execution-Kafka_Test-Suite">
     <test name="siddhi-execution-kafka-unit-tests" preserve-order="true">
         <classes>
-            <!--class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceTestCase" /-->
-            <!-- TODO uncomment when the text mapper is released -->
-            <!--<class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceHATestCase" />
-            <class name="org.wso2.extension.siddhi.io.kafka.sink.KafkaSinkTestCase" />-->
             <class name="org.wso2.extension.siddhi.io.kafka.SequencedMessagingTestCase" />
+            <class name="org.wso2.extension.siddhi.io.kafka.sink.KafkaSinkTestCase" />
+            <class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceTestCase" />
+            <class name="org.wso2.extension.siddhi.io.kafka.multidc.KafkaMultiDCSinkTestCases" />
+            <!-- TODO uncomment when the text mapper is released -->
+            <!--<class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceHATestCase" />-->
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> Adding new Sink to facilitate multi-data center deployments

## Goals
> With this sink it's possible to sequence and send messages to two data centers 

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
As a User, I want to publish the same event to two Kafka brokers with a sequence number to each message so that I can identify each message separately and prevent processing same event again and identify gaps in the event stream.

## Release note
> Kafka Multi data center sink

## Documentation
> N/A

## Training
> N/A

## Certification
>N/A this is transparent to the user

## Marketing
> N/A

## Automation tests
- Integration tests were written.
   
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> N/A

## Migrations (if applicable)
>N/A

## Test environment
> JDK 8.0, Kafka 0.9.1
 
## Learning
> N/A