### PR TITLE
 Fix pausing logic

### DIFF
--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -22,13 +22,13 @@
 <suite name="Siddhi-Execution-Kafka_Test-Suite" parallel="false" thread-count="1">
     <test name="siddhi-execution-kafka-unit-tests" preserve-order="true">
         <classes>
-            <!--<class name="org.wso2.extension.siddhi.io.kafka.SequencedMessagingTestCase" />-->
-            <!--<class name="org.wso2.extension.siddhi.io.kafka.sink.KafkaSinkTestCase" />-->
-            <!--<class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceTestCase" />-->
-            <!--<class name="org.wso2.extension.siddhi.io.kafka.sink.KafkaSinkwithBinaryMapperTestCase" />-->
+            <class name="org.wso2.extension.siddhi.io.kafka.SequencedMessagingTestCase" />
+            <class name="org.wso2.extension.siddhi.io.kafka.sink.KafkaSinkTestCase" />
+            <class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceTestCase" />
+            <class name="org.wso2.extension.siddhi.io.kafka.sink.KafkaSinkwithBinaryMapperTestCase" />
 
-            <!--<class name="org.wso2.extension.siddhi.io.kafka.multidc.KafkaMultiDCSinkTestCases"/>-->
-            <!--<class name="org.wso2.extension.siddhi.io.kafka.multidc.KafkaMultiDCSourceTestCases"/>-->
+            <class name="org.wso2.extension.siddhi.io.kafka.multidc.KafkaMultiDCSinkTestCases"/>
+            <class name="org.wso2.extension.siddhi.io.kafka.multidc.KafkaMultiDCSourceTestCases"/>
             <class name="org.wso2.extension.siddhi.io.kafka.multidc.KafkaMultiDCSourceSynchronizerTestCases"/>
             <!--TODO uncomment when the text mapper is released -->
             <!--<class name="org.wso2.extension.siddhi.io.kafka.source.KafkaSourceHATestCase"/>-->

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <commons-io.version>2.5</commons-io.version>
         <kafka.client.version>0.10.0.0</kafka.client.version>
         <xml.mapper.version>4.0.11</xml.mapper.version>
-        <text.mapper.version>1.0.12</text.mapper.version>
+        <text.mapper.version>1.0.14</text.mapper.version>
         <binary.mapper.version>1.0.10</binary.mapper.version>
         <jacoco.version>0.7.9</jacoco.version>
 


### PR DESCRIPTION
## Purpose
Pausing logic of Kafka consumer had two issues. 
- When paused thread will busy wait
- Shutdown have to wait till pause is called to properly shutdown the thread

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8
