### PR TITLE
Fix build failure

### DIFF
--- a/component/src/test/java/org/wso2/extension/siddhi/io/kafka/source/KafkaSourceTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/kafka/source/KafkaSourceTestCase.java
@@ -78,6 +78,7 @@ public class KafkaSourceTestCase {
             receivedEventNameList = new ArrayList<>(2);
             receivedValueList = new ArrayList<>(2);
             KafkaTestUtil.createTopic(topics, 1);
+            Thread.sleep(1000);
             SiddhiManager siddhiManager = new SiddhiManager();
             SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
                     "@App:name('TestExecutionPlan') @App:transportChannelCreationEnabled('false')" +


### PR DESCRIPTION
## Purpose
Fix build failure by introducing delay to get test-cases created.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
