### PR TITLE
Allow kafka to send transport sync properties and update accordingly 

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/multidc/source/KafkaMultiDCSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/multidc/source/KafkaMultiDCSource.java
@@ -253,7 +253,20 @@ class Interceptor implements SourceEventListener {
     
     @Override
     public void onEvent(Object event, String[] strings) {
+        onEventReceive(event, strings, null);
+    }
 
+    @Override
+    public void onEvent(Object event, String[] strings, String[] strings1) {
+        onEventReceive(event, strings, strings1);
+    }
+
+    @Override
+    public StreamDefinition getStreamDefinition() {
+        return null;
+    }
+
+    private void onEventReceive(Object event, String[] strings, String[] strings1) {
         if (!isBinaryMessage) {
             String eventString = (String) event;
             int headerStartingIndex = eventString.indexOf(KafkaSink.SEQ_NO_HEADER_DELIMITER);
@@ -281,12 +294,6 @@ class Interceptor implements SourceEventListener {
                 LOG.warn("Sequence number is not contained in the message. Dropping the message");
             }
         }
-
-    }
-
-    @Override
-    public StreamDefinition getStreamDefinition() {
-        return null;
     }
 }
 

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/multidc/source/KafkaMultiDCSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/multidc/source/KafkaMultiDCSource.java
@@ -110,8 +110,8 @@ public class KafkaMultiDCSource extends Source {
     private SourceSynchronizer synchronizer;
 
     @Override
-    public void init(SourceEventListener sourceEventListener, OptionHolder optionHolder, String[] transportPropertyNames,
-                     ConfigReader configReader, SiddhiAppContext siddhiAppContext) {
+    public void init(SourceEventListener sourceEventListener, OptionHolder optionHolder, String[]
+            transportPropertyNames, ConfigReader configReader, SiddhiAppContext siddhiAppContext) {
         this.eventListener = sourceEventListener;
         String serverList = optionHolder.validateAndGetStaticValue(KafkaSource
             .ADAPTOR_SUBSCRIBER_ZOOKEEPER_CONNECT_SERVERS);

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/ConsumerKafkaGroup.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/ConsumerKafkaGroup.java
@@ -39,6 +39,7 @@ public class ConsumerKafkaGroup {
     private final Properties props;
     private List<KafkaConsumerThread> kafkaConsumerThreadList = new ArrayList<>();
     private Map<String, Map<Integer, Long>> topicOffsetMap = new HashMap<>();
+    private Map<String, Map<Integer, Long>> syncPropertyCallbackTopicOffsetMap;
     private ScheduledExecutorService executorService;
     private String threadingOption;
     private boolean isBinaryMessage;
@@ -46,7 +47,8 @@ public class ConsumerKafkaGroup {
 
     ConsumerKafkaGroup(String topics[], String partitions[], Properties props, Map<String, Map<Integer, Long>>
             topicOffsetMap, Map<String, Map<SequenceKey, Integer>> perConsumerLastReceivedSeqNo, String threadingOption,
-                       ScheduledExecutorService executorService, boolean isBinaryMessage) {
+                       ScheduledExecutorService executorService, boolean isBinaryMessage,
+                       Map<String, Map<Integer, Long>> syncPropertyCallbackTopicOffsetMap) {
         this.threadingOption = threadingOption;
         this.topicOffsetMap = topicOffsetMap;
         this.perConsumerLastReceivedSeqNo = perConsumerLastReceivedSeqNo;
@@ -55,6 +57,7 @@ public class ConsumerKafkaGroup {
         this.props = props;
         this.executorService = executorService;
         this.isBinaryMessage = isBinaryMessage;
+        this.syncPropertyCallbackTopicOffsetMap = syncPropertyCallbackTopicOffsetMap;
     }
 
     public void setTopicOffsetMap(Map<String, Map<Integer, Long>> topicOffsetMap) {
@@ -69,8 +72,11 @@ public class ConsumerKafkaGroup {
     }
 
     void restore(final Map<String, Map<Integer, Long>> topic) {
-        kafkaConsumerThreadList.forEach(kafkaConsumerThread -> kafkaConsumerThread.restore(topic));
+        kafkaConsumerThreadList.forEach(kafkaConsumerThread -> kafkaConsumerThread.restore(topic,
+                syncPropertyCallbackTopicOffsetMap));
     }
+
+    // update topicOffset
 
     void shutdown() {
         kafkaConsumerThreadList.forEach(KafkaConsumerThread::shutdownConsumer);
@@ -81,7 +87,7 @@ public class ConsumerKafkaGroup {
             if (KafkaSource.SINGLE_THREADED.equals(threadingOption)) {
                 KafkaConsumerThread kafkaConsumerThread =
                         new KafkaConsumerThread(sourceEventListener, topics, partitions, props, topicOffsetMap,
-                                false, isBinaryMessage);
+                                false, isBinaryMessage, syncPropertyCallbackTopicOffsetMap);
                 kafkaConsumerThreadList.add(kafkaConsumerThread);
                 LOG.info("Kafka Consumer thread starting to listen on topic(s): " + Arrays.toString(topics) +
                         " with partition/s: " + Arrays.toString(partitions));
@@ -89,7 +95,8 @@ public class ConsumerKafkaGroup {
                 for (String topic : topics) {
                     KafkaConsumerThread kafkaConsumerThread =
                             new KafkaConsumerThread(sourceEventListener, new String[]{topic}, partitions, props,
-                                    topicOffsetMap, false, isBinaryMessage);
+                                    topicOffsetMap, false, isBinaryMessage,
+                                    syncPropertyCallbackTopicOffsetMap);
                     kafkaConsumerThreadList.add(kafkaConsumerThread);
                     LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                             " with partition/s: " + Arrays.toString(partitions));
@@ -100,7 +107,7 @@ public class ConsumerKafkaGroup {
                         KafkaConsumerThread kafkaConsumerThread =
                                 new KafkaConsumerThread(sourceEventListener, new String[]{topic},
                                         new String[]{partition}, props, topicOffsetMap, true,
-                                        isBinaryMessage);
+                                        isBinaryMessage, syncPropertyCallbackTopicOffsetMap);
                         kafkaConsumerThreadList.add(kafkaConsumerThread);
                         LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                                 " with partition: " + partition);

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/ConsumerKafkaGroup.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/ConsumerKafkaGroup.java
@@ -76,8 +76,6 @@ public class ConsumerKafkaGroup {
                 syncPropertyCallbackTopicOffsetMap));
     }
 
-    // update topicOffset
-
     void shutdown() {
         kafkaConsumerThreadList.forEach(KafkaConsumerThread::shutdownConsumer);
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/KafkaConsumerThread.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/KafkaConsumerThread.java
@@ -116,19 +116,21 @@ public class KafkaConsumerThread implements Runnable {
 
     void restore(Map<String, Map<Integer, Long>> topicOffsetMap) {
         final Lock consumerLock = this.consumerLock;
-        for (String topic : topics) {
-            Map<Integer, Long> offsetMap = topicOffsetMap.get(topic);
-            if (null != offsetMap) {
-                for (Map.Entry<Integer, Long> entry : offsetMap.entrySet()) {
-                    TopicPartition partition = new TopicPartition(topic, entry.getKey());
-                    if (partitionsList.contains(partition)) {
-                        LOG.info("Seeking partition: " + partition + " for topic: " + topic + " offset: " + (entry
-                                .getValue() + 1));
-                        try {
-                            consumerLock.lock();
-                            consumer.seek(partition, entry.getValue() + 1);
-                        } finally {
-                            consumerLock.unlock();
+        if (null != topicOffsetMap) {
+            for (String topic : topics) {
+                Map<Integer, Long> offsetMap = topicOffsetMap.get(topic);
+                if (null != offsetMap) {
+                    for (Map.Entry<Integer, Long> entry : offsetMap.entrySet()) {
+                        TopicPartition partition = new TopicPartition(topic, entry.getKey());
+                        if (partitionsList.contains(partition)) {
+                            LOG.info("Seeking partition: " + partition + " for topic: " + topic + " offset: " + (entry
+                                    .getValue() + 1));
+                            try {
+                                consumerLock.lock();
+                                consumer.seek(partition, entry.getValue() + 1);
+                            } finally {
+                                consumerLock.unlock();
+                            }
                         }
                     }
                 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/kafka/source/KafkaSource.java
@@ -193,9 +193,9 @@ public class KafkaSource extends Source implements SourceSyncCallback {
     private String topicOffsetMapConfig;
     private boolean isRestored = false;
     private SiddhiAppContext siddhiAppContext;
-    public static final String TOPIC = "topic";
-    public static final String PARTITION = "partition";
-    public static final String OFFSET = "offSet";
+    private static final String TOPIC = "topic";
+    private static final String PARTITION = "partition";
+    private static final String OFFSET = "offSet";
 
 
     @Override

--- a/component/src/test/java/org/wso2/extension/siddhi/io/kafka/multidc/KafkaMultiDCSourceSynchronizerTestCases.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/kafka/multidc/KafkaMultiDCSourceSynchronizerTestCases.java
@@ -50,6 +50,11 @@ public class KafkaMultiDCSourceSynchronizerTestCases {
         public void onEvent(Object o, String[] strings) {
             eventsArrived.add(o);
         }
+
+        @Override
+        public void onEvent(Object o, String[] strings, String[] strings1) {
+            eventsArrived.add(o);
+        }
     };
 
     @BeforeMethod

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </profiles>
 
     <properties>
-        <siddhi.version>4.2.17</siddhi.version>
+        <siddhi.version>4.4.0</siddhi.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.8</testng.version>
         <commons.logging.version>1.1.1</commons.logging.version>


### PR DESCRIPTION
## Purpose
Allow kakfa source to send transport sync properties so that passive node can update its kafka source state properly

## Goals
To stop consuming duplicate events

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes