### PR TITLE
Support enable/disable automatic committing

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/ConsumerKafkaGroup.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/ConsumerKafkaGroup.java
@@ -42,7 +42,7 @@ public class ConsumerKafkaGroup {
     private KafkaSource.KafkaSourceState kafkaSourceState;
 
     ConsumerKafkaGroup(String[] topics, String[] partitions, Properties props, String threadingOption,
-                       ScheduledExecutorService executorService, boolean isBinaryMessage,
+                       ScheduledExecutorService executorService, boolean isBinaryMessage, boolean enableAutoCommit,
                        SourceEventListener sourceEventListener) {
         this.threadingOption = threadingOption;
         this.topics = topics;
@@ -54,7 +54,7 @@ public class ConsumerKafkaGroup {
         if (KafkaSource.SINGLE_THREADED.equals(threadingOption)) {
             KafkaConsumerThread kafkaConsumerThread =
                     new KafkaConsumerThread(sourceEventListener, topics, partitions, props,
-                            false, isBinaryMessage);
+                            false, isBinaryMessage, enableAutoCommit);
             kafkaConsumerThreadList.add(kafkaConsumerThread);
             LOG.info("Kafka Consumer thread starting to listen on topic(s): " + Arrays.toString(topics) +
                     " with partition/s: " + Arrays.toString(partitions));
@@ -62,7 +62,7 @@ public class ConsumerKafkaGroup {
             for (String topic : topics) {
                 KafkaConsumerThread kafkaConsumerThread =
                         new KafkaConsumerThread(sourceEventListener, new String[]{topic}, partitions, props,
-                                false, isBinaryMessage);
+                                false, isBinaryMessage, enableAutoCommit);
                 kafkaConsumerThreadList.add(kafkaConsumerThread);
                 LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                         " with partition/s: " + Arrays.toString(partitions));
@@ -73,7 +73,7 @@ public class ConsumerKafkaGroup {
                     KafkaConsumerThread kafkaConsumerThread =
                             new KafkaConsumerThread(sourceEventListener, new String[]{topic},
                                     new String[]{partition}, props, true,
-                                    isBinaryMessage);
+                                    isBinaryMessage, enableAutoCommit);
                     kafkaConsumerThreadList.add(kafkaConsumerThread);
                     LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                             " with partition: " + partition);

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -127,8 +127,8 @@ import java.util.concurrent.ScheduledExecutorService;
                                 + "Siddhi Periodic State Persistence when `enable.auto.commit` property "
                                 + "is set to `true`.\n "
                                 + "When you would like more control over exactly when offsets are committed, you can "
-                                + "set `enable.auto.commit` to false and Siddhi will call the commit method"
-                                + "on the consumer once the records are successfully processed at the Source. "
+                                + "set `enable.auto.commit` to false and Siddhi will commit the offset once the "
+                                + "records are successfully processed at the Source. "
                                 + "When `enable.auto.commit` is set to `false`, manual committing would introduce "
                                 + "a latency during consumption.",
                         type = {DataType.BOOL},

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -117,7 +117,7 @@ import java.util.concurrent.ScheduledExecutorService;
                         optional = true,
                         defaultValue = "null"),
                 @Parameter(name = "enable.auto.commit",
-                        description = "This parameter specifies whether to commit offsets automatically.`\n "
+                        description = "This parameter specifies whether to commit offsets automatically. \n"
                                 + "By default, as the Siddhi Kafka source reads messages from Kafka, "
                                 + "it will periodically(Default value is set to 1000ms. You can configure it with "
                                 + "`auto.commit.interval.ms` property as an `optional.configuration`) "
@@ -125,7 +125,7 @@ import java.util.concurrent.ScheduledExecutorService;
                                 + "for the partitions it is reading from back to Kafka. "
                                 + "To guarantee at-least-once processing, we recommend you to enable "
                                 + "Siddhi Periodic State Persistence when `enable.auto.commit` property "
-                                + "is set to `true`.\n "
+                                + "is set to `true`. \n"
                                 + "When you would like more control over exactly when offsets are committed, you can "
                                 + "set `enable.auto.commit` to false and Siddhi will commit the offset once the "
                                 + "records are successfully processed at the Source. "

--- a/component/src/test/java/io/siddhi/extension/io/kafka/SequencedMessagingTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/kafka/SequencedMessagingTestCase.java
@@ -105,7 +105,7 @@ public class SequencedMessagingTestCase {
                 "@info(name = 'DataReceiveQuery') " +
                 "@source(type='kafka', topic.list='IntermediateTopic-0', group.id='test1', " +
                 "threading.option='topic.wise', seq.enabled='true', bootstrap.servers='localhost:9092', " +
-                "partition.no.list='0', is.binary.message='true', @map(type='binary')) " +
+                "partition.no.list='0', is.binary.message='true', enable.auto.commit='false', @map(type='binary')) " +
                 "Define stream FooStream1 (symbol string, count long);" +
 
                 "from FooStream1 select * insert into BarStream1;";

--- a/component/src/test/java/io/siddhi/extension/io/kafka/source/KafkaSourceTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/kafka/source/KafkaSourceTestCase.java
@@ -837,7 +837,7 @@ public class KafkaSourceTestCase {
                     "@App:name('TestExecutionPlan') " +
                             "define stream BarStream (symbol string, price float, volume long); " +
                             "@info(name = 'query1') " +
-                            "@source(type='kafka', topic.list='non_existing_topic1', "
+                            "@source(type='kafka', topic.list='non_existing_topic1', enable.auto.commit='false', "
                             + "group.id='test_non_existing_topic1', " +
                             "threading.option='single.thread', bootstrap.servers='localhost:9092'," +
                             "@map(type='xml'))" +


### PR DESCRIPTION
## Purpose
> Fixes #117

> At the moment, we avoided auto committing and manually committed by default. This manual committing introduced a latency during consumption since the fetching and committing shared the same connection.

> With the fix, by default, as the Siddhi Kafka source reads messages from Kafka, it will periodically(Default value is set to 1000ms. You can configure it with`auto.commit.interval.ms` property as an `optional.configuration`) commit its current offset (defined as the offset of the next message to be read) for the partitions it is reading from back to Kafka. o guarantee at-least-once processing, we recommend you to enable Siddhi Periodic State Persistence when `enable.auto.commit` property is set to `true`.
When you would like more control over exactly when offsets are committed, you can set `enable.auto.commit` to false and Siddhi will call the commit method on the consumer once the records are successfully processed at the Source. When `enable.auto.commit` is set to `false`, manual committing would introduce a latency during consumption.

## Approach
> Support configuring automatic committing at Siddhi Kafka Source.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related Issues
> https://github.com/siddhi-io/siddhi-io-kafka/issues/117