### PR TITLE
Support providing handle over committing the offset

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/ConsumerKafkaGroup.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/ConsumerKafkaGroup.java
@@ -42,7 +42,7 @@ public class ConsumerKafkaGroup {
     private KafkaSource.KafkaSourceState kafkaSourceState;
 
     ConsumerKafkaGroup(String[] topics, String[] partitions, Properties props, String threadingOption,
-                       ScheduledExecutorService executorService, boolean isBinaryMessage, boolean enableAutoCommit,
+                       ScheduledExecutorService executorService, boolean isBinaryMessage, boolean enableOffsetCommit,
                        SourceEventListener sourceEventListener) {
         this.threadingOption = threadingOption;
         this.topics = topics;
@@ -54,7 +54,7 @@ public class ConsumerKafkaGroup {
         if (KafkaSource.SINGLE_THREADED.equals(threadingOption)) {
             KafkaConsumerThread kafkaConsumerThread =
                     new KafkaConsumerThread(sourceEventListener, topics, partitions, props,
-                            false, isBinaryMessage, enableAutoCommit);
+                            false, isBinaryMessage, enableOffsetCommit);
             kafkaConsumerThreadList.add(kafkaConsumerThread);
             LOG.info("Kafka Consumer thread starting to listen on topic(s): " + Arrays.toString(topics) +
                     " with partition/s: " + Arrays.toString(partitions));
@@ -62,7 +62,7 @@ public class ConsumerKafkaGroup {
             for (String topic : topics) {
                 KafkaConsumerThread kafkaConsumerThread =
                         new KafkaConsumerThread(sourceEventListener, new String[]{topic}, partitions, props,
-                                false, isBinaryMessage, enableAutoCommit);
+                                false, isBinaryMessage, enableOffsetCommit);
                 kafkaConsumerThreadList.add(kafkaConsumerThread);
                 LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                         " with partition/s: " + Arrays.toString(partitions));
@@ -73,7 +73,7 @@ public class ConsumerKafkaGroup {
                     KafkaConsumerThread kafkaConsumerThread =
                             new KafkaConsumerThread(sourceEventListener, new String[]{topic},
                                     new String[]{partition}, props, true,
-                                    isBinaryMessage, enableAutoCommit);
+                                    isBinaryMessage, enableOffsetCommit);
                     kafkaConsumerThreadList.add(kafkaConsumerThread);
                     LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                             " with partition: " + partition);

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
@@ -74,7 +74,7 @@ public class KafkaConsumerThread implements Runnable {
         this.isPartitionWiseThreading = isPartitionWiseThreading;
         this.isBinaryMessage = isBinaryMessage;
         this.enableOffsetCommit = enableOffsetCommit;
-        this.enableAutoCommit = Boolean.parseBoolean(props.getProperty(ADAPTOR_ENABLE_AUTO_COMMIT, "false"));
+        this.enableAutoCommit = Boolean.parseBoolean(props.getProperty(ADAPTOR_ENABLE_AUTO_COMMIT, "true"));
         this.consumerThreadId = buildId();
         lock = new ReentrantLock();
         condition = lock.newCondition();

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
@@ -39,13 +39,14 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static io.siddhi.extension.io.kafka.source.KafkaSource.ADAPTOR_ENABLE_AUTO_COMMIT;
+
 /**
  * This runnable processes each Kafka message and sends it to siddhi.
  */
 public class KafkaConsumerThread implements Runnable {
 
     private static final Logger LOG = Logger.getLogger(KafkaConsumerThread.class);
-    public static final String ADAPTOR_ENABLE_AUTO_COMMIT = "enable.auto.commit";
     private final KafkaConsumer<byte[], byte[]> consumer;
     // KafkaConsumer is not thread safe, hence we need a lock
     private final Lock consumerLock = new ReentrantLock();

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -471,7 +471,6 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
         //If it stops heart-beating for a period of time longer than session.timeout.ms then it will be considered dead
         // and its partitions will be assigned to another process
         props.put("session.timeout.ms", "30000");
-        props.put("enable.auto.commit", "false");
         props.put("auto.offset.reset", "earliest");
         props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         if (!isBinaryMessage) {

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -115,21 +115,23 @@ import java.util.concurrent.ScheduledExecutorService;
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = "null"),
-                @Parameter(name = "enable.offset.commit",
+                @Parameter(name = "enable.offsets.commit",
                         description = "This parameter specifies whether to commit offsets. \n"
                                 + "By default, as the Siddhi Kafka source reads messages from Kafka, "
                                 + "Siddhi will commit the offset once the records are successfully "
-                                + "processed at the Source. If `enable.auto.commit` property is set to `true` "
-                                + "along with this property as an `optional.configuration`, "
-                                + "it will periodically(default: 1000ms. Configurable with `auto.commit.interval.ms` "
+                                + "processed at the Source. \n"
+                                + "If both `enable.offsets.commit` property and `enable.auto.commit` "
+                                + "`optional.configuration` property are set to `true`, Source will "
+                                + "periodically(default: 1000ms. Configurable with `auto.commit.interval.ms` "
                                 + "property as an `optional.configuration`) commit its current offset "
                                 + "(defined as the offset of the next message to be read) "
                                 + "for the partitions it is reading from back to Kafka. "
                                 + "To guarantee at-least-once processing, we recommend you to enable "
                                 + "Siddhi Periodic State Persistence when `enable.auto.commit` property "
                                 + "is set to `true`. \n"
-                                + "When `enable.auto.commit` is set to `false` along with this property, "
-                                + "Source would manually commit the offset which might introduce "
+                                + "When `enable.auto.commit` `optional.configuration` is set to `false` "
+                                + "while `enable.offsets.commit` property is set to `true`, "
+                                + "Source would manually commit the offset. This might introduce "
                                 + "a latency during consumption.",
                         type = {DataType.BOOL},
                         optional = true,
@@ -190,7 +192,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
     public static final String ADAPTOR_SUBSCRIBER_ZOOKEEPER_CONNECT_SERVERS = "bootstrap.servers";
     public static final String ADAPTOR_SUBSCRIBER_PARTITION_NO_LIST = "partition.no.list";
     public static final String ADAPTOR_ENABLE_AUTO_COMMIT = "enable.auto.commit";
-    public static final String ADAPTOR_ENABLE_OFFSET_COMMIT = "enable.offset.commit";
+    public static final String ADAPTOR_ENABLE_OFFSET_COMMIT = "enable.offsets.commit";
     public static final String ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES = "optional.configuration";
     private static final String TOPIC_OFFSET_MAP = "topic.offsets.map";
     public static final String THREADING_OPTION = "threading.option";

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -129,7 +129,8 @@ import java.util.concurrent.ScheduledExecutorService;
                                 + "To guarantee at-least-once processing, we recommend you to enable "
                                 + "Siddhi Periodic State Persistence when `enable.auto.commit` property "
                                 + "is set to `true`. \n"
-                                + "When `enable.auto.commit` is set to `false`, manual committing would introduce "
+                                + "When `enable.auto.commit` is set to `false` along with this property, "
+                                + "Source would manually commit the offset which might introduce "
                                 + "a latency during consumption.",
                         type = {DataType.BOOL},
                         optional = true,

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -117,22 +117,21 @@ import java.util.concurrent.ScheduledExecutorService;
                         defaultValue = "null"),
                 @Parameter(name = "enable.offsets.commit",
                         description = "This parameter specifies whether to commit offsets. \n"
-                                + "By default, as the Siddhi Kafka source reads messages from Kafka, "
-                                + "Siddhi will commit the offset once the records are successfully "
-                                + "processed at the Source. \n"
-                                + "If both `enable.offsets.commit` property and `enable.auto.commit` "
-                                + "`optional.configuration` property are set to `true`, Source will "
-                                + "periodically(default: 1000ms. Configurable with `auto.commit.interval.ms` "
-                                + "property as an `optional.configuration`) commit its current offset "
-                                + "(defined as the offset of the next message to be read) "
-                                + "for the partitions it is reading from back to Kafka. "
+                                + "If the manual asynchronous offset committing is needed, `enable.offsets.commit` "
+                                + "should be `true` and `enable.auto.commit` should be `false`. \n"
+                                + "If periodical committing is needed `enable.offsets.commit` should be `true` and "
+                                + "`enable.auto.commit` should be `true`. \n"
+                                + "If committing is not needed, `enable.offsets.commit` should be `false`. \n"
+                                + "\n"
+                                + "Note: `enable.auto.commit` is an `optional.configuration` property. If it is set to "
+                                + "`true`, Source will periodically(default: 1000ms. Configurable with "
+                                + "`auto.commit.interval.ms` property as an `optional.configuration`) commit its "
+                                + "current offset (defined as the offset of the next message to be read) "
+                                + "for the partitions it is reading from back to Kafka. \n"
                                 + "To guarantee at-least-once processing, we recommend you to enable "
                                 + "Siddhi Periodic State Persistence when `enable.auto.commit` property "
                                 + "is set to `true`. \n"
-                                + "When `enable.auto.commit` `optional.configuration` is set to `false` "
-                                + "while `enable.offsets.commit` property is set to `true`, "
-                                + "Source would manually commit the offset. This might introduce "
-                                + "a latency during consumption.",
+                                + "During manual committing, it might introduce a latency during consumption.",
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "true"),


### PR DESCRIPTION
## Purpose
> If enable.offset.commit property is set to true (true by default), along with enable.auto.commit as true, Siddhi Kafka Source would commit the offset periodically. 
> If enable.offset.commit property is set to true (true by default), along with enable.auto.commit as false,  Siddhi Kafka Source would commit the offset manually in asynchronous manner. This might introduce a latency during consumption since same connection is being used for fetching and committing.
>  If enable.offset.commit property is set to false, Siddhi Kafka Source would not commit the offsets at all.

Fixes #91 