### PR TITLE
Replace ScheduledExecutorService with ExecutorService

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -48,7 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ExecutorService;
 
 /**
  * This class implements a Kafka source to receive events from a kafka cluster.
@@ -256,7 +256,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
     public void connect(ConnectionCallback connectionCallback, KafkaSourceState kafkaSourceState)
             throws ConnectionUnavailableException {
         try {
-            ScheduledExecutorService executorService = siddhiAppContext.getScheduledExecutorService();
+            ExecutorService executorService = siddhiAppContext.getExecutorService();
             consumerKafkaGroup = new ConsumerKafkaGroup(topics, partitions,
                     KafkaSource.createConsumerConfig(bootstrapServers, groupID, optionalConfigs, isBinaryMessage,
                             enableOffsetCommit),


### PR DESCRIPTION
## Purpose
Resolve #80

## Goals
Get ExecutorService from SiddhiAppcontext instead of ScheduledExecutorService.

## Approach
Earlier siddhi-io-kafka source used ScheduledExecutorService from SiddhiAppContext to handle partition wise threads and that SheduledExecuterService has only 5 threadpools. So Kafka source can't handle more than 5 partition even though the user provides more than 5 partitions from the `partition.no.list` parameter. In order to solve this, ExecutoreService is used instead of SheduleExecutorService from the SiddhiAppContext

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes