### PR TITLE
Linking to the correct issue page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Then, you have to add necessary client jars (from <KAFKA_HOME>/libs directory) t
 
 * We encourage users to ask questions and get support via <a target="_blank" href="https://stackoverflow.com/questions/tagged/siddhi">StackOverflow</a>, make sure to add the `siddhi` tag to the issue for better response.
 
-* If you find any issues related to the extension please report them on <a target="_blank" href="https://github.com/siddhi-io/siddhi-execution-string/issues">the issue tracker</a>.
+* If you find any issues related to the extension please report them on <a target="_blank" href="https://github.com/siddhi-io/siddhi-io-kafka/issues">the issue tracker</a>.
 
 * For production support and other contribution related information refer <a target="_blank" href="https://siddhi.io/community/">Siddhi Community</a> documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,6 @@ Then, you have to add necessary client jars (from <KAFKA_HOME>/libs directory) t
 
 * We encourage users to ask questions and get support via <a target="_blank" href="https://stackoverflow.com/questions/tagged/siddhi">StackOverflow</a>, make sure to add the `siddhi` tag to the issue for better response.
 
-* If you find any issues related to the extension please report them on <a target="_blank" href="https://github.com/siddhi-io/siddhi-execution-string/issues">the issue tracker</a>.
+* If you find any issues related to the extension please report them on <a target="_blank" href="https://github.com/siddhi-io/siddhi-io-kafka/issues">the issue tracker</a>.
 
 * For production support and other contribution related information refer <a target="_blank" href="https://siddhi.io/community/">Siddhi Community</a> documentation.


### PR DESCRIPTION
## Purpose
Previously pointed to https://github.com/siddhi-io/siddhi-execution-string/issues which is not this repository

## Release note
Fixed typo in README.md