### PR TITLE
Add sync and asyncronous committing configurable and bug fix for sending events after siddhi app undeployed

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/ConsumerKafkaGroup.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/ConsumerKafkaGroup.java
@@ -45,7 +45,7 @@ public class ConsumerKafkaGroup {
 
     ConsumerKafkaGroup(String[] topics, String[] partitions, Properties props, String threadingOption,
                        ExecutorService executorService, boolean isBinaryMessage, boolean enableOffsetCommit,
-                       SourceEventListener sourceEventListener) {
+                       boolean asyncCommit, SourceEventListener sourceEventListener) {
         this.threadingOption = threadingOption;
         this.topics = topics;
         this.partitions = partitions;
@@ -56,7 +56,7 @@ public class ConsumerKafkaGroup {
         if (KafkaSource.SINGLE_THREADED.equals(threadingOption)) {
             KafkaConsumerThread kafkaConsumerThread =
                     new KafkaConsumerThread(sourceEventListener, topics, partitions, props,
-                            false, isBinaryMessage, enableOffsetCommit);
+                            false, isBinaryMessage, enableOffsetCommit, asyncCommit);
             kafkaConsumerThreadList.add(kafkaConsumerThread);
             LOG.info("Kafka Consumer thread starting to listen on topic(s): " + Arrays.toString(topics) +
                     " with partition/s: " + Arrays.toString(partitions));
@@ -64,7 +64,7 @@ public class ConsumerKafkaGroup {
             for (String topic : topics) {
                 KafkaConsumerThread kafkaConsumerThread =
                         new KafkaConsumerThread(sourceEventListener, new String[]{topic}, partitions, props,
-                                false, isBinaryMessage, enableOffsetCommit);
+                                false, isBinaryMessage, enableOffsetCommit, asyncCommit);
                 kafkaConsumerThreadList.add(kafkaConsumerThread);
                 LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                         " with partition/s: " + Arrays.toString(partitions));
@@ -75,7 +75,7 @@ public class ConsumerKafkaGroup {
                     KafkaConsumerThread kafkaConsumerThread =
                             new KafkaConsumerThread(sourceEventListener, new String[]{topic},
                                     new String[]{partition}, props, true,
-                                    isBinaryMessage, enableOffsetCommit);
+                                    isBinaryMessage, enableOffsetCommit, asyncCommit);
                     kafkaConsumerThreadList.add(kafkaConsumerThread);
                     LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                             " with partition: " + partition);

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/ConsumerKafkaGroup.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/ConsumerKafkaGroup.java
@@ -45,7 +45,7 @@ public class ConsumerKafkaGroup {
 
     ConsumerKafkaGroup(String[] topics, String[] partitions, Properties props, String threadingOption,
                        ExecutorService executorService, boolean isBinaryMessage, boolean enableOffsetCommit,
-                       boolean asyncCommit, SourceEventListener sourceEventListener) {
+                       boolean enableAsyncCommit, SourceEventListener sourceEventListener) {
         this.threadingOption = threadingOption;
         this.topics = topics;
         this.partitions = partitions;
@@ -56,7 +56,7 @@ public class ConsumerKafkaGroup {
         if (KafkaSource.SINGLE_THREADED.equals(threadingOption)) {
             KafkaConsumerThread kafkaConsumerThread =
                     new KafkaConsumerThread(sourceEventListener, topics, partitions, props,
-                            false, isBinaryMessage, enableOffsetCommit, asyncCommit);
+                            false, isBinaryMessage, enableOffsetCommit, enableAsyncCommit);
             kafkaConsumerThreadList.add(kafkaConsumerThread);
             LOG.info("Kafka Consumer thread starting to listen on topic(s): " + Arrays.toString(topics) +
                     " with partition/s: " + Arrays.toString(partitions));
@@ -64,7 +64,7 @@ public class ConsumerKafkaGroup {
             for (String topic : topics) {
                 KafkaConsumerThread kafkaConsumerThread =
                         new KafkaConsumerThread(sourceEventListener, new String[]{topic}, partitions, props,
-                                false, isBinaryMessage, enableOffsetCommit, asyncCommit);
+                                false, isBinaryMessage, enableOffsetCommit, enableAsyncCommit);
                 kafkaConsumerThreadList.add(kafkaConsumerThread);
                 LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                         " with partition/s: " + Arrays.toString(partitions));
@@ -75,7 +75,7 @@ public class ConsumerKafkaGroup {
                     KafkaConsumerThread kafkaConsumerThread =
                             new KafkaConsumerThread(sourceEventListener, new String[]{topic},
                                     new String[]{partition}, props, true,
-                                    isBinaryMessage, enableOffsetCommit, asyncCommit);
+                                    isBinaryMessage, enableOffsetCommit, enableAsyncCommit);
                     kafkaConsumerThreadList.add(kafkaConsumerThread);
                     LOG.info("Kafka Consumer thread starting to listen on topic: " + topic +
                             " with partition: " + partition);

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
@@ -64,7 +64,7 @@ public class KafkaConsumerThread implements Runnable {
     private boolean isBinaryMessage = false;
     private boolean enableOffsetCommit = false;
     private boolean enableAutoCommit = false;
-    private boolean asyncCommit;
+    private boolean enableAsyncCommit;
     private boolean consumerClosed;
     private ReentrantLock lock;
     private Condition condition;
@@ -72,7 +72,7 @@ public class KafkaConsumerThread implements Runnable {
 
     KafkaConsumerThread(SourceEventListener sourceEventListener, String[] topics, String[] partitions,
                         Properties props, boolean isPartitionWiseThreading, boolean isBinaryMessage,
-                        boolean enableOffsetCommit, boolean asyncCommit) {
+                        boolean enableOffsetCommit, boolean enableAsyncCommit) {
         this.consumer = new KafkaConsumer<>(props);
         this.sourceEventListener = sourceEventListener;
         this.topics = topics;
@@ -82,7 +82,7 @@ public class KafkaConsumerThread implements Runnable {
         this.enableOffsetCommit = enableOffsetCommit;
         this.enableAutoCommit = Boolean.parseBoolean(props.getProperty(ADAPTOR_ENABLE_AUTO_COMMIT, "true"));
         this.consumerThreadId = buildId();
-        this.asyncCommit = asyncCommit;
+        this.enableAsyncCommit = enableAsyncCommit;
         lock = new ReentrantLock();
         condition = lock.newCondition();
         if (null != partitions) {
@@ -249,7 +249,7 @@ public class KafkaConsumerThread implements Runnable {
                     try {
                         consumerLock.lock();
                         if (!records.isEmpty()) {
-                            if (asyncCommit) {
+                            if (enableAsyncCommit) {
                                 consumer.commitAsync(new KafkaOffsetCommitCallback());
                             } else {
                                 try {

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
@@ -255,7 +255,7 @@ public class KafkaConsumerThread implements Runnable {
                                 try {
                                     consumer.commitSync();
                                 } catch (KafkaException e) {
-                                    LOG.error("Exception occurred when committing offsets Synchronously");
+                                    LOG.error("Exception occurred when committing offsets Synchronously", e);
                                 }
                             }
                         }

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -135,6 +135,13 @@ import java.util.concurrent.ExecutorService;
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "true"),
+                @Parameter(name = "commit.async",
+                        description = "This parameter will changes the type of the committing offsets returned on " +
+                                "the last poll for the subscribed list of topics and partitions.\n" +
+                                "When `commit.async` is set to true, committing will be an asynchronous call.",
+                        type = {DataType.BOOL},
+                        optional = true,
+                        defaultValue = "true"),
                 @Parameter(name = "optional.configuration",
                         description = "This parameter contains all the other possible configurations that the " +
                                 "consumer is created with. \n" +
@@ -192,6 +199,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
     public static final String ADAPTOR_SUBSCRIBER_PARTITION_NO_LIST = "partition.no.list";
     public static final String ADAPTOR_ENABLE_AUTO_COMMIT = "enable.auto.commit";
     public static final String ADAPTOR_ENABLE_OFFSET_COMMIT = "enable.offsets.commit";
+    public static final String ADAPTOR_ENABLE_ASYNC_COMMIT = "async.commit";
     public static final String ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES = "optional.configuration";
     private static final String TOPIC_OFFSET_MAP = "topic.offsets.map";
     public static final String THREADING_OPTION = "threading.option";
@@ -212,6 +220,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
     private boolean seqEnabled = false;
     private boolean isBinaryMessage;
     private boolean enableOffsetCommit;
+    private boolean asyncCommit;
     private String topicOffsetMapConfig;
     private SiddhiAppContext siddhiAppContext;
     private KafkaSourceState kafkaSourceState;
@@ -238,6 +247,8 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
                 "false"));
         enableOffsetCommit = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(ADAPTOR_ENABLE_OFFSET_COMMIT,
                 "true"));
+        asyncCommit = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(ADAPTOR_ENABLE_ASYNC_COMMIT,
+                "true"));
         topicOffsetMapConfig = optionHolder.validateAndGetStaticValue(TOPIC_OFFSET_MAP, null);
         if (PARTITION_WISE.equals(threadingOption) && null == partitions) {
             throw new SiddhiAppValidationException("Threading option is selected as 'partition.wise' but " +
@@ -257,11 +268,13 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
             throws ConnectionUnavailableException {
         try {
             ExecutorService executorService = siddhiAppContext.getExecutorService();
-            consumerKafkaGroup = new ConsumerKafkaGroup(topics, partitions,
-                    KafkaSource.createConsumerConfig(bootstrapServers, groupID, optionalConfigs, isBinaryMessage,
-                            enableOffsetCommit),
-                    threadingOption, executorService, isBinaryMessage, enableOffsetCommit, sourceEventListener);
-
+            consumerKafkaGroup =
+                    new ConsumerKafkaGroup(
+                            topics, partitions,
+                            KafkaSource.createConsumerConfig(bootstrapServers, groupID, optionalConfigs,
+                                    isBinaryMessage, enableOffsetCommit),
+                            threadingOption, executorService, isBinaryMessage, enableOffsetCommit, asyncCommit,
+                            sourceEventListener);
             checkTopicsAvailableInCluster();
             checkPartitionsAvailableForTheTopicsInCluster();
             this.kafkaSourceState = kafkaSourceState;

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -135,10 +135,10 @@ import java.util.concurrent.ExecutorService;
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "true"),
-                @Parameter(name = "commit.async",
+                @Parameter(name = "enable.async.commit",
                         description = "This parameter will changes the type of the committing offsets returned on " +
                                 "the last poll for the subscribed list of topics and partitions.\n" +
-                                "When `commit.async` is set to true, committing will be an asynchronous call.",
+                                "When `enable.async.commit` is set to true, committing will be an asynchronous call.",
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "true"),
@@ -199,7 +199,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
     public static final String ADAPTOR_SUBSCRIBER_PARTITION_NO_LIST = "partition.no.list";
     public static final String ADAPTOR_ENABLE_AUTO_COMMIT = "enable.auto.commit";
     public static final String ADAPTOR_ENABLE_OFFSET_COMMIT = "enable.offsets.commit";
-    public static final String ADAPTOR_ENABLE_ASYNC_COMMIT = "async.commit";
+    public static final String ADAPTOR_ENABLE_ASYNC_COMMIT = "enable.async.commit";
     public static final String ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES = "optional.configuration";
     private static final String TOPIC_OFFSET_MAP = "topic.offsets.map";
     public static final String THREADING_OPTION = "threading.option";
@@ -220,7 +220,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
     private boolean seqEnabled = false;
     private boolean isBinaryMessage;
     private boolean enableOffsetCommit;
-    private boolean asyncCommit;
+    private boolean enableAsyncCommit;
     private String topicOffsetMapConfig;
     private SiddhiAppContext siddhiAppContext;
     private KafkaSourceState kafkaSourceState;
@@ -247,7 +247,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
                 "false"));
         enableOffsetCommit = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(ADAPTOR_ENABLE_OFFSET_COMMIT,
                 "true"));
-        asyncCommit = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(ADAPTOR_ENABLE_ASYNC_COMMIT,
+        enableAsyncCommit = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(ADAPTOR_ENABLE_ASYNC_COMMIT,
                 "true"));
         topicOffsetMapConfig = optionHolder.validateAndGetStaticValue(TOPIC_OFFSET_MAP, null);
         if (PARTITION_WISE.equals(threadingOption) && null == partitions) {
@@ -273,7 +273,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
                             topics, partitions,
                             KafkaSource.createConsumerConfig(bootstrapServers, groupID, optionalConfigs,
                                     isBinaryMessage, enableOffsetCommit),
-                            threadingOption, executorService, isBinaryMessage, enableOffsetCommit, asyncCommit,
+                            threadingOption, executorService, isBinaryMessage, enableOffsetCommit, enableAsyncCommit,
                             sourceEventListener);
             checkTopicsAvailableInCluster();
             checkPartitionsAvailableForTheTopicsInCluster();


### PR DESCRIPTION
## Purpose
> Add parameters to enable/ disable asynchronous committing
> bug fix for sending events after siddhi app is undeployed

## Goals
> Enable synchronous  as well as asynchronous committing
> Fix https://github.com/wso2/product-sp/issues/1055#issue-536345895 

## Approach
> Add additional parameter
> Add a flag not to send after the consumer.close() in the disconnect() function, even if the recent consumer.poll() records have not sent to Streams

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes