### PR TITLE
Add Kafka Sink Error Stream Test case

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/kafka/sink/KafkaSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/sink/KafkaSink.java
@@ -291,12 +291,14 @@ public class KafkaSink extends Sink<KafkaSink.KafkaSinkState> {
                     }
                     sendToMetrics(metadata, pushedTimestamp);
                 } catch (ExecutionException e) {
-                    metrics.getErrorCountWithoutPartition(
-                            topic, streamId, e.getClass().getSimpleName()).inc();
-                    // When the siddhi app user has not given a partition, then this stat won't be published.
-                    if (partitionNo != null) {
-                        metrics.getErrorCountPerStream(
-                                streamId, topic, Integer.parseInt(partitionNo), e.getClass().getSimpleName()).inc();
+                    if (metrics != null) {
+                        metrics.getErrorCountWithoutPartition(
+                                topic, streamId, e.getClass().getSimpleName()).inc();
+                        // When the siddhi app user has not given a partition, then this stat won't be published.
+                        if (partitionNo != null) {
+                            metrics.getErrorCountPerStream(
+                                    streamId, topic, Integer.parseInt(partitionNo), e.getClass().getSimpleName()).inc();
+                        }
                     }
                     if (e.getMessage().contains("apache.kafka.common.errors.TimeoutException")) {
                         throw new ConnectionUnavailableException("TimeoutException occurred when trying to send " +

--- a/component/src/test/java/io/siddhi/extension/io/kafka/sink/ErrorHandlingTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/kafka/sink/ErrorHandlingTestCase.java
@@ -25,8 +25,6 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.stream.output.StreamCallback;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 

--- a/component/src/test/java/io/siddhi/extension/io/kafka/sink/ErrorHandlingTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/kafka/sink/ErrorHandlingTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.kafka.sink;
+
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.stream.output.StreamCallback;
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ErrorHandlingTestCase {
+    static final Logger LOG = Logger.getLogger(ErrorHandlingTestCase.class);
+    private volatile int count;
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void initClassVariables() {
+        count = 0;
+        eventArrived = false;
+    }
+
+    @Test
+    public void testErrorStream() throws InterruptedException {
+        LOG.info("Sending messages to error stream when the broker is not available");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntimeSource = siddhiManager.createSiddhiAppRuntime(
+                "@App:name('ErrorHandlerApp') " +
+                        "define stream inputStream (symbol string, price float, volume long); " +
+                        "define stream kafkaErrorStream (symbol string, price float, volume long); " +
+                        "@info(name = 'query1') " +
+                        "@OnError(action='STREAM')" +
+                        "@sink(type='kafka', topic='single_topic', is.synchronous='true', " +
+                        "on.error='STREAM', " +
+                        "bootstrap.servers='localhost:9092',\n" +
+                        "optional.configuration='retry.backoff.ms:1,metadata.fetch.timeout.ms:10," +
+                        "request.timeout.ms:5," +
+                        "timeout.ms:10', " +
+                        "@map(type='xml'))" +
+                        "Define stream kafkaSinkStream (symbol string, price float, volume long);" +
+                        "from inputStream select symbol, price, volume insert into kafkaSinkStream;" +
+                        "from !kafkaSinkStream select symbol, price, volume insert into kafkaErrorStream;");
+        siddhiAppRuntimeSource.addCallback("kafkaErrorStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    LOG.info(event);
+                    eventArrived = true;
+                    count++;
+                }
+            }
+        });
+        siddhiAppRuntimeSource.start();
+        InputHandler fooStream = siddhiAppRuntimeSource.getInputHandler("inputStream");
+        fooStream.send(new Object[]{"single_topic", 55.6f, 100L});
+        Thread.sleep(1000);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertEquals(1, count);
+        siddhiAppRuntimeSource.shutdown();
+    }
+}

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
             <class name="io.siddhi.extension.io.kafka.sink.KafkaSinkTestCase" />
             <class name="io.siddhi.extension.io.kafka.source.KafkaSourceTestCase" />
             <class name="io.siddhi.extension.io.kafka.sink.KafkaSinkwithBinaryMapperTestCase" />
+            <class name="io.siddhi.extension.io.kafka.sink.ErrorHandlingTestCase" />
 
             <class name="io.siddhi.extension.io.kafka.multidc.KafkaMultiDCSinkTestCases"/>
             <class name="io.siddhi.extension.io.kafka.multidc.KafkaMultiDCSourceTestCases"/>


### PR DESCRIPTION
## Purpose
Fix bug and add test case for error stream support for Kafka Sink.
Git issue: https://github.com/siddhi-io/siddhi-io-kafka/issues/143

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/siddhi-io/siddhi-io-kafka/pull/144