### PR TITLE
Add support for message decoding via Schema registry

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -111,6 +111,70 @@
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.si.metrics.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-serializer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-locator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-schema</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -149,14 +213,34 @@
                         <Export-Package>
                             io.siddhi.extension.io.kafka.*,
                             io.confluent.*,
-                            org.codehaus.jackson.*
+                            !com.google.protobuf.*,
+                            com.google.*,
                         </Export-Package>
                         <Import-Package>
                             io.siddhi.core.*;version="${siddhi.version.range}",
                             io.siddhi.annotation.*;version="${siddhi.version.range}",
                             io.siddhi.query.api.*;version="${siddhi.version.range}",
-                            *;resolution:=optional
+                            org.apache.kafka.*,
+                            org.apache.log4j.*,
+                            com.google.protobuf.*,
+                            org.wso2.carbon.si.metrics.core.*,
+                            org.wso2.carbon.metrics.core.*,
+                            org.slf4j.*,
+                            com.google.protobuf.*,
                         </Import-Package>
+                        <Private-Package>
+                            org.glassfish.jersey.*,
+                            jakarta.ws.rs.*,
+                            javax.ws.rs.*,
+                            org.codehaus.jackson.*,
+                            org.glassfish.jersey.*,
+                            org.glassfish.hk2.*,
+                            com.fasterxml.jackson.*,
+                            com.squareup.wire.*,
+                            com.google.guava.*
+                            com.google.common.base.*,
+                            kotlin.*
+                        </Private-Package>
                         <Include-Resource>
                             META-INF=target/classes/META-INF
                         </Include-Resource>

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaConsumerThread.java
@@ -184,6 +184,8 @@ public class KafkaConsumerThread implements Runnable {
                 records = consumer.poll(100);
             } catch (CommitFailedException ex) {
                 LOG.warn("Consumer poll() failed." + ex.getMessage(), ex);
+            } catch (Throwable t) {
+                LOG.error("Consumer poll() failed.", t);
             } finally {
                 consumerLock.unlock();
             }

--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -18,6 +18,7 @@
 
 package io.siddhi.extension.io.kafka.source;
 
+import com.google.protobuf.GeneratedMessageV3;
 import io.siddhi.annotation.Example;
 import io.siddhi.annotation.Extension;
 import io.siddhi.annotation.Parameter;
@@ -355,7 +356,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
 
     @Override
     public Class[] getOutputEventClasses() {
-        return new Class[]{String.class, ByteBuffer.class};
+        return new Class[]{String.class, ByteBuffer.class, GeneratedMessageV3.class};
     }
 
     @Override

--- a/docs/api/5.0.9.md
+++ b/docs/api/5.0.9.md
@@ -12,7 +12,7 @@
 <span id="syntax" class="md-typeset" style="display: block; font-weight: bold;">Syntax</span>
 
 ```
-@sink(type="kafka", bootstrap.servers="<STRING>", topic="<STRING>", partition.no="<INT>", sequence.id="<STRING>", key="<STRING>", is.binary.message="<BOOL>", optional.configuration="<STRING>", @map(...)))
+@sink(type="kafka", bootstrap.servers="<STRING>", topic="<STRING>", partition.no="<INT>", sequence.id="<STRING>", key="<STRING>", is.binary.message="<BOOL>", optional.configuration="<STRING>", is.synchronous="<BOOL>", @map(...)))
 ```
 
 <span id="query-parameters" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">QUERY PARAMETERS</span>
@@ -78,6 +78,14 @@
         <td style="vertical-align: top; word-wrap: break-word"><p style="word-wrap: break-word;margin: 0;">This parameter contains all the other possible configurations that the producer is created with. <br>e.g., <code>producer.type:async,batch.size:200</code></p></td>
         <td style="vertical-align: top">null</td>
         <td style="vertical-align: top">STRING</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top">is.synchronous</td>
+        <td style="vertical-align: top; word-wrap: break-word"><p style="word-wrap: break-word;margin: 0;">The Kafka sync will publish the events to the server synchronously when thevalue is set to <code>true</code>, and asynchronously if otherwise</p></td>
+        <td style="vertical-align: top">false</td>
+        <td style="vertical-align: top">BOOL</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>

--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,20 @@
         <text.mapper.version>2.0.5</text.mapper.version>
         <binary.mapper.version>2.0.5</binary.mapper.version>
         <jacoco.version>0.7.9</jacoco.version>
-        <carbon.analytics.version>3.0.48</carbon.analytics.version>
-        <confluent.version>3.0.0</confluent.version>
+        <confluent.version>7.0.1</confluent.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <carbon.analytics.version>3.0.48</carbon.analytics.version>
+        <protobuf.version>3.17.3</protobuf.version>
+        <codehaus.version>1.9.10</codehaus.version>
+        <ws.rs.version>2.0</ws.rs.version>
+        <glassfish.jersey.version>2.34</glassfish.jersey.version>
+        <glassfish.version>2.4.0</glassfish.version>
+        <jakarta.version>3.0.0</jakarta.version>
+        <fasterxml.version>2.9.8</fasterxml.version>
+        <squareup.version>3.6.0</squareup.version>
+        <guava.version>30.1.1-jre</guava.version>
+        <kotlin.version>1.4.10</kotlin.version>
     </properties>
 
     <scm>
@@ -196,6 +206,86 @@
                 <groupId>org.wso2.carbon.analytics</groupId>
                 <artifactId>org.wso2.carbon.si.metrics.core</artifactId>
                 <version>${carbon.analytics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-schema-registry</artifactId>
+                <version>${confluent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-protobuf-serializer</artifactId>
+                <version>${confluent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-jaxrs</artifactId>
+                <version>${codehaus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>${ws.rs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-common</artifactId>
+                <version>${glassfish.jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-api</artifactId>
+                <version>${glassfish.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-locator</artifactId>
+                <version>${glassfish.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-utils</artifactId>
+                <version>${glassfish.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${jakarta.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${fasterxml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${fasterxml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${fasterxml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-schema</artifactId>
+                <version>${squareup.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Purpose
This PR adds support to decode a `protobuf` messages via a schema registry.

Resolves https://github.com/wso2/streaming-integrator/issues/242

Sample app as follows.
```
@App:name("protobuf")

@source(
    type='kafka',
    group.id = 'siddhiconsumer',
    is.synchronous='true',
    threading.option='single.thread',
    topic.list='StringsOnlyOptionOne',
    bootstrap.servers='localhost:9092',
    is.binary.message='true',
    optional.configuration="key.deserializer:org.apache.kafka.common.serialization.StringDeserializer,value.deserializer:io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer,specific.protobuf.key.type:com.google.protobuf.GeneratedMessageV3,derive.type:false,schema.registry.url:http://localhost:8081",
    @map(type='protobuf', schema='registry',
        @attributes(a='Snack.colour', b='Snack.name')))
define stream LowProductionAlertStreamProtoBuf (a string, b string);

from LowProductionAlertStreamProtoBuf#log("Hit for protobuf2")
select *
insert into LogStream;
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes