### PR TITLE
Fix kafka offset from option not working 

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/kafka/source/KafkaSource.java
@@ -314,7 +314,7 @@ public class KafkaSource extends Source<KafkaSource.KafkaSourceState> implements
                     "true"));
             topicOffsetMapConfig = optionHolder.validateAndGetStaticValue(TOPIC_OFFSET_MAP, null);
         }
-        partitions = (partitionList != null) ? partitionList.split(KafkaIOUtils.HEADER_SEPARATOR) : null;
+        partitions = (partitionList != null) ? partitionList.split(KafkaIOUtils.HEADER_SEPARATOR) : new String[]{"0"};
         topics = topicList.split(KafkaIOUtils.HEADER_SEPARATOR);
         seqEnabled = optionHolder.validateAndGetStaticValue(SEQ_ENABLED, "false").equalsIgnoreCase("true");
         optionalConfigs = optionHolder.validateAndGetStaticValue(ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES, null);

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -19,27 +19,15 @@
 
 <FindBugsFilter>
     <Match>
-        <Class name="io.siddhi.extension.io.kafka.source.KafkaSource"/>
-        <Bug pattern="IMPROPER_UNICODE"/>
-    </Match>
-    <Match>
-        <Class name="io.siddhi.extension.io.kafka.source.KafkaReplayResponseSource"/>
-        <Bug pattern="IMPROPER_UNICODE"/>
-    </Match>
-    <Match>
-        <Class name="io.siddhi.extension.io.kafka.source.KafkaConsumerThread"/>
-        <Bug pattern="IMPROPER_UNICODE"/>
-    </Match>
-    <Match>
-        <Class name="io.siddhi.extension.io.kafka.sink.KafkaSink"/>
-        <Bug pattern="IMPROPER_UNICODE"/>
-    </Match>
-    <Match>
         <Class name="io.siddhi.extension.io.kafka.multidc.source.SourceSynchronizer"/>
         <Bug pattern="DLS_DEAD_LOCAL_STORE"/>
     </Match>
     <Match>
         <Package name="~io\.siddhi\.extension\.io\.kafka.*"/>
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC"/>
+    </Match>
+    <Match>
+        <Class name="io.siddhi.extension.io.kafka.source.KafkaSource"/>
+        <Bug pattern="RCN_REDUNDANT_COMPARISON_OF_NULL_AND_NONNULL_VALUE"/>
     </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -332,12 +332,26 @@
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>
-            <plugin>
+            <plugin><!-- Overridden from parent pom to exclude generated sources -->
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
+                <configuration combine.self="override">
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/findbugs</spotbugsXmlOutputDirectory>
                     <excludeFilterFile>${maven.findbugsplugin.version.exclude}</excludeFilterFile>
+                    <!--Exclude generated sources-->
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>analyze-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
 


### PR DESCRIPTION
The following sample is not working in siddhi,
This gives a null pointer error because the default partition list is null inside kafka code and after fixing that even the message offset is not considered when passing the content to the sink. 

```
@App:name("HelloKafka")

@App:description('Consume events from a Kafka Topic and log the messages on the console.')

@source(type='kafka',
        topic.list='productions',
        threading.option='single.thread',
        group.id="group1",
        bootstrap.servers='localhost:9092',
        partition.no.list='0',
        topic.offsets.map='productions=2',
        @map(type='json'))
define stream SweetProductionStream (name string, amount double);

@sink(type='log')
define stream OutputStream (name string, amount double);

from SweetProductionStream
select str:upper(name) as name, amount
insert into OutputStream;
```